### PR TITLE
Fix issue #3 by resetting the iterator

### DIFF
--- a/lib/RDF/NS/Curated.pm
+++ b/lib/RDF/NS/Curated.pm
@@ -111,6 +111,7 @@ sub qname {
 	  if($uri =~ m/^$namespace(${r_PN_LOCAL})$/) {
 		  $ln = $1;
 		  $pr = $prefix;
+          my $n = scalar keys (%{$self->{prefix_namespace}}); # reset iterator
 		  last;
 	  }
   }

--- a/t/uri-prefix.t
+++ b/t/uri-prefix.t
@@ -36,11 +36,13 @@ is($ns->prefix('http://clearly.invalid/'), undef, 'Non-existent URI OK');
 is($ns->prefix('http://creativecommons.org/ns#'), 'cc', 'CC prefix OK, test the cache');
 
 is($ns->qname('http://www.w3.org/ns/rdfa#term'), 'rdfa:term', 'OK qname for rdfa:term');
+is($ns->qname('http://www.w3.org/ns/rdfa#term'), 'rdfa:term', 'Check reset: still OK for rdfa:term');
+
 my @got = $ns->qname('http://purl.org/dc/terms/name');
 #use Data::Dumper;
 #warn Dumper(\@got);
 my @expected = ('dc','name');
-is_deeply(\@got, \@expected, 'OK qname for rdfa and term in list context');
+is_deeply(\@got, \@expected, 'OK qname for dc and name in list context');
 
 is($ns->qname('http://clearly.invalid/vocab#term'), undef, 'OK when non-existing URI');
 is(($ns->qname('http://clearly.invalid/vocab#term')), undef, 'OK in list context for non-existing URI');


### PR DESCRIPTION
The test case t/uri-prefix.t demonstrated that the each() iterator isn't reset after a successful match. The fix does a reset of the iterator whenever the while loop is aborted with last.  This should resolve #3.